### PR TITLE
Fix lib name and cmake target include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,8 @@ if(WIN32 OR (LINUX AND NOT ANDROID) OR (APPLE AND NOT IOS) )
         gareplxx.h gareplxx.cpp
     )
     target_link_libraries(libgoodasm PRIVATE Qt6::Quick)
+    target_include_directories(libgoodasm INTERFACE ${CMAKE_CURRENT_SOURCE_DIR})
+    set_property(TARGET libgoodasm PROPERTY OUTPUT_NAME goodasm)
 
     ## replxx will soon replace readline.
     target_link_libraries(goodasm PRIVATE Qt6::Quick libgoodasm replxx::replxx)


### PR DESCRIPTION
On linux, the library builds to `liblibgoodasm.a`. The `set_property()` line fixes it.
Also added `target_include_directories` to make it easier to use in other projects.

Some other project's CMakeLists.txt can have:
```
...
add_subdirectory(ext/goodasm)
target_link_libraries(MyOtherProject PUBLIC libgoodasm)
...
```

Now files in MyOtherProject can `#include <goodasm.h>`